### PR TITLE
soluciono bug en crearSupervisor

### DIFF
--- a/src/Services/Supervisor/CrearSupervisor.js
+++ b/src/Services/Supervisor/CrearSupervisor.js
@@ -16,7 +16,7 @@ async function CrearSupervisor(empleadoId, sectorId) {
         } else {
             const superv = await Supervisor.create({
                 codigo,
-                EmpleadoId: empleadoId,
+                empleadoId: empleadoId,
                 SectorId: sectorId
             })
             return{


### PR DESCRIPTION
Corrijo el atributo EmpleadoId que estaba mal escrito y no me dejaba crear nuevos supervisores.